### PR TITLE
tests: assert during unit test

### DIFF
--- a/test_tar_changes.py
+++ b/test_tar_changes.py
@@ -22,4 +22,4 @@ def test_clear_old_changes_sources(tmpdir, monkeypatch):
     tarchanges.clear_old_changes_sources()
     sources = tmpdir.join('sources')
     expected = '3a393d427d5b16c33cf24da91244cc7a  ceph-12.2.8.tar.gz\n'
-    sources.read() == expected
+    assert sources.read() == expected


### PR DESCRIPTION
The `test_clear_old_changes_sources()` method never asserted anything. Add the assert so that we actually raise an error if the test fails.