### PR TITLE
Wip log gitlab user

### DIFF
--- a/rdopkg_tar/tar_changes.py
+++ b/rdopkg_tar/tar_changes.py
@@ -113,8 +113,11 @@ def clear_old_changes_sources():
 
 def commit_distgit_amend(suffix):
     """ Ammend commit with original gitlab user. """
+    rng = 'HEAD~..HEAD'
+    message = git('log', '--format=%s%n%n%b', rng, log_cmd=False)
+    message += '\n\n' + suffix
     cmd = ['commit','-a','-F','-','--amend']
-    git(*cmd, input=suffix, print_output=True)
+    git(*cmd, input=message, print_output=True)
     
 
 def main():

--- a/rdopkg_tar/tar_changes.py
+++ b/rdopkg_tar/tar_changes.py
@@ -8,6 +8,7 @@ from rdopkg.utils.cmd import run
 from rdopkg.utils.git import git
 from rdopkg import guess
 import rdopkg.actions.distgit.actions
+import os
 
 
 def diff_filenames(base, branch):
@@ -181,8 +182,18 @@ def main():
         clear_old_changes_sources()
         run(fedpkg, 'upload', tarball, direct=True)
 
-    # Commit everything to dist-git
-    rdopkg.actions.distgit.actions.commit_distgit_update(branch=branch,
+    # Check for the original commiter username in jenkins env variables. 
+    # If it exists then build a header file for the new commit to preserve the original commiter.
+    userName = os.environ.get('gitlabUserUsername')
+    if userName:
+        with open("commit_header.txt","w") as fp:
+            fp.write("Original GitLab commiter: " + userName)
+        rdopkg.actions.distgit.actions.commit_distgit_update(branch=branch,
+                                                         local_patches_branch=patches_branch,
+                                                         commit_header_file="commit_header.txt")
+    else:
+        # Commit everything to dist-git
+        rdopkg.actions.distgit.actions.commit_distgit_update(branch=branch,
                                                          local_patches_branch=patches_branch)
     # Show the final commit
     rdopkg.actions.distgit.actions.final_spec_diff(branch=branch)

--- a/rdopkg_tar/tar_changes.py
+++ b/rdopkg_tar/tar_changes.py
@@ -8,7 +8,6 @@ from rdopkg.utils.cmd import run
 from rdopkg.utils.git import git
 from rdopkg import guess
 import rdopkg.actions.distgit.actions
-import rdopkg.exceptions
 import os
 
 
@@ -114,8 +113,6 @@ def clear_old_changes_sources():
 
 def commit_distgit_ammend(branch, patch_branch, msg):
     """ Ammend commit with original gitlab user. """
-    if git.is_clean():
-        raise rdopkg.exception.NoDistgitChangesFound()
     cmd = ['commit','-a','-F','-','--ammend']
     git(*cmd, input=msg, print_output=True)
     

--- a/rdopkg_tar/tar_changes.py
+++ b/rdopkg_tar/tar_changes.py
@@ -111,10 +111,10 @@ def clear_old_changes_sources():
                 f.write(line)
 
 
-def commit_distgit_amend(branch, patch_branch, msg):
+def commit_distgit_amend(suffix):
     """ Ammend commit with original gitlab user. """
     cmd = ['commit','-a','-F','-','--amend']
-    git(*cmd, input=msg, print_output=True)
+    git(*cmd, input=suffix, print_output=True)
     
 
 def main():
@@ -192,9 +192,7 @@ def main():
     # If it exists then build a header file for the new commit to preserve the original commiter.
     userName = os.environ.get('gitlabUserName')
     if userName:
-        commit_distgit_amend(branch=branch, 
-                                patch_branch=patches_branch, 
-                                msg = "orig commiter: " + userName)
+        commit_distgit_amend(suffix="orig commiter: " + userName)
     else:
         # Commit everything to dist-git
         rdopkg.actions.distgit.actions.commit_distgit_update(branch=branch,

--- a/rdopkg_tar/tar_changes.py
+++ b/rdopkg_tar/tar_changes.py
@@ -191,15 +191,16 @@ def main():
         clear_old_changes_sources()
         run(fedpkg, 'upload', tarball, direct=True)
 
+    # Commit everything to dist-git
+    rdopkg.actions.distgit.actions.commit_distgit_update(branch=branch,
+                                                         local_patches_branch=patches_branch)
+
     # Check for the original commiter username in jenkins env variables. 
     # If it exists then build a header file for the new commit to preserve the original commiter.
     userName = os.environ.get('gitlabUserName')
     if userName:
         commit_distgit_amend(suffix="orig commiter: " + userName)
-    else:
-        # Commit everything to dist-git
-        rdopkg.actions.distgit.actions.commit_distgit_update(branch=branch,
-                                                         local_patches_branch=patches_branch)
+
     # Show the final commit
     rdopkg.actions.distgit.actions.final_spec_diff(branch=branch)
 

--- a/rdopkg_tar/tar_changes.py
+++ b/rdopkg_tar/tar_changes.py
@@ -112,7 +112,11 @@ def clear_old_changes_sources():
 
 
 def commit_distgit_amend(suffix):
-    """ Ammend commit with original gitlab user. """
+    """ 
+    Ammend commit with original gitlab user. 
+    
+    :param suffix: String to be amended to commit.
+    """
     rng = 'HEAD~..HEAD'
     message = git('log', '--format=%s%n%n%b', rng, log_cmd=False)
     message += '\n\n' + suffix
@@ -196,7 +200,7 @@ def main():
                                                          local_patches_branch=patches_branch)
 
     # Check for the original commiter username in jenkins env variables. 
-    # If it exists then build a header file for the new commit to preserve the original commiter.
+    # If it exists, then ammend a suffix to the commit.
     userName = os.environ.get('gitlabUserName')
     if userName:
         commit_distgit_amend(suffix="orig commiter: " + userName)

--- a/rdopkg_tar/tar_changes.py
+++ b/rdopkg_tar/tar_changes.py
@@ -184,7 +184,7 @@ def main():
 
     # Check for the original commiter username in jenkins env variables. 
     # If it exists then build a header file for the new commit to preserve the original commiter.
-    userName = os.environ.get('gitlabUserUsername')
+    userName = os.environ.get('gitlabUserName')
     if userName:
         with open("commit_header.txt","w") as fp:
             fp.write("Original GitLab commiter: " + userName)

--- a/rdopkg_tar/tar_changes.py
+++ b/rdopkg_tar/tar_changes.py
@@ -8,6 +8,7 @@ from rdopkg.utils.cmd import run
 from rdopkg.utils.git import git
 from rdopkg import guess
 import rdopkg.actions.distgit.actions
+import rdopkg.exceptions
 import os
 
 
@@ -111,6 +112,14 @@ def clear_old_changes_sources():
                 f.write(line)
 
 
+def commit_distgit_ammend(branch, patch_branch, msg):
+    """ Ammend commit with original gitlab user. """
+    if git.is_clean():
+        raise rdopkg.exception.NoDistgitChangesFound()
+    cmd = ['commit','-a','-F','-','--ammend']
+    git(*cmd, input=msg, print_output=True)
+    
+
 def main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -186,11 +195,9 @@ def main():
     # If it exists then build a header file for the new commit to preserve the original commiter.
     userName = os.environ.get('gitlabUserName')
     if userName:
-        with open("commit_header.txt","w") as fp:
-            fp.write("Original GitLab commiter: " + userName)
-        rdopkg.actions.distgit.actions.commit_distgit_update(branch=branch,
-                                                         local_patches_branch=patches_branch,
-                                                         commit_header_file="commit_header.txt")
+        commit_distgit_ammend(branch=branch, 
+                                patch_branch=patches_branch, 
+                                msg = "orig commiter: " + userName)
     else:
         # Commit everything to dist-git
         rdopkg.actions.distgit.actions.commit_distgit_update(branch=branch,

--- a/rdopkg_tar/tar_changes.py
+++ b/rdopkg_tar/tar_changes.py
@@ -111,9 +111,9 @@ def clear_old_changes_sources():
                 f.write(line)
 
 
-def commit_distgit_ammend(branch, patch_branch, msg):
+def commit_distgit_amend(branch, patch_branch, msg):
     """ Ammend commit with original gitlab user. """
-    cmd = ['commit','-a','-F','-','--ammend']
+    cmd = ['commit','-a','-F','-','--amend']
     git(*cmd, input=msg, print_output=True)
     
 
@@ -192,7 +192,7 @@ def main():
     # If it exists then build a header file for the new commit to preserve the original commiter.
     userName = os.environ.get('gitlabUserName')
     if userName:
-        commit_distgit_ammend(branch=branch, 
+        commit_distgit_amend(branch=branch, 
                                 patch_branch=patches_branch, 
                                 msg = "orig commiter: " + userName)
     else:

--- a/test_tar_changes.py
+++ b/test_tar_changes.py
@@ -27,4 +27,7 @@ def test_clear_old_changes_sources(tmpdir, monkeypatch):
 
 def test_commit_distgit_ammend(monkeypatch):
     pass
-
+    # things we need to supply:
+    # - branch = current git branch
+    # - local_patches_branch = patches branch from args
+    # - msg = updated commit message w/ original commiter's username

--- a/test_tar_changes.py
+++ b/test_tar_changes.py
@@ -1,6 +1,7 @@
 import os
 import importlib.machinery
 import importlib.util
+from rdopkg.utils.git import git
 import py.path
 
 loader = importlib.machinery.SourceFileLoader('tarchanges', 'tar-changes')
@@ -26,3 +27,4 @@ def test_clear_old_changes_sources(tmpdir, monkeypatch):
 
 def test_commit_distgit_ammend(monkeypatch):
     pass
+

--- a/test_tar_changes.py
+++ b/test_tar_changes.py
@@ -23,3 +23,6 @@ def test_clear_old_changes_sources(tmpdir, monkeypatch):
     sources = tmpdir.join('sources')
     expected = '3a393d427d5b16c33cf24da91244cc7a  ceph-12.2.8.tar.gz\n'
     assert sources.read() == expected
+
+def test_commit_distgit_ammend(monkeypatch):
+    pass

--- a/test_tar_changes.py
+++ b/test_tar_changes.py
@@ -27,7 +27,3 @@ def test_clear_old_changes_sources(tmpdir, monkeypatch):
 
 def test_commit_distgit_amend(monkeypatch):
     pass
-    # things we need to supply:
-    # - branch = current git branch
-    # - local_patches_branch = patches branch from args
-    # - msg = updated commit message w/ original commiter's username

--- a/test_tar_changes.py
+++ b/test_tar_changes.py
@@ -25,7 +25,7 @@ def test_clear_old_changes_sources(tmpdir, monkeypatch):
     expected = '3a393d427d5b16c33cf24da91244cc7a  ceph-12.2.8.tar.gz\n'
     assert sources.read() == expected
 
-def test_commit_distgit_ammend(monkeypatch):
+def test_commit_distgit_amend(monkeypatch):
     pass
     # things we need to supply:
     # - branch = current git branch


### PR DESCRIPTION
I believe all the changes needed to amend a commit with the original gitlab username are complete. I just recently polished up some comments and a doc string. The test that @ktdreyer wrote tests that the commit_distgit_ammend(suffix) method successfully amends a commit with a given suffix.