### PR TITLE
tox.ini: add {posargs} to testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ skipsdist = True
 deps =
     -r{toxinidir}/requirements.txt
     pytest
-commands = py.test -v
+commands = py.test -v {posargs}


### PR DESCRIPTION
This allows us to pass arguments to the `py.test` invocation. In particular, we may want to pass `--pdb` to get into an interactive debugger on test failures.